### PR TITLE
implement employee hierarchy retrieval endpoint

### DIFF
--- a/EmployeeHierarchy.API/Controllers/EmployeesController.cs
+++ b/EmployeeHierarchy.API/Controllers/EmployeesController.cs
@@ -10,7 +10,7 @@ using Domain;
 [ApiController]
 [Route("api/[controller]")]
 public class EmployeesController
-    (ICreateClient createClient, IUpdateClient updateClient, IDeleteClient deleteClient)
+    (ICreateClient createClient, IUpdateClient updateClient, IDeleteClient deleteClient, IReadClient readClient)
     : ControllerBase
 {
     [HttpPost("create-employee")]
@@ -140,5 +140,12 @@ public class EmployeesController
         {
             return this.StatusCode(500, new { error = "Internal server error", details = ex.Message });
         }
+    }
+
+    [HttpGet("get_hierarchy")]
+    public async Task<IActionResult> GetHierarchyTree()
+    {
+        var hierarchy = await readClient.GetEmployeeHierarchyAsync();
+        return this.Ok(hierarchy);
     }
 }

--- a/EmployeeHierarchy.API/Program.cs
+++ b/EmployeeHierarchy.API/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddScoped<ICreateClient, CreateClient>();
 builder.Services.AddScoped<IUpdateClient, UpdateClient>();
 builder.Services.AddScoped<IDeleteClient, DeleteClient>();
+builder.Services.AddScoped<IReadClient, ReadClient>();
 builder.Services.AddSingleton<DbConnectionFactory>();
 builder.Services.AddScoped<IDbConnection>(sp =>
     sp.GetRequiredService<DbConnectionFactory>().CreateConnection());

--- a/EmployeeHierarchy.Domain/IDeleteClient.cs
+++ b/EmployeeHierarchy.Domain/IDeleteClient.cs
@@ -1,6 +1,5 @@
 namespace EmployeeHierarchy.Domain;
 
-using Entities;
 using System.Threading.Tasks;
 
 public interface IDeleteClient

--- a/EmployeeHierarchy.Domain/IReadClient.cs
+++ b/EmployeeHierarchy.Domain/IReadClient.cs
@@ -1,0 +1,9 @@
+namespace EmployeeHierarchy.Domain;
+
+using Models.Response;
+using System.Threading.Tasks;
+
+public interface IReadClient
+{
+    Task<IEnumerable<EmployeeHierarchyResponse>> GetEmployeeHierarchyAsync();
+}

--- a/EmployeeHierarchy.Domain/Models/Response/EmployeeHierarchyResponse.cs
+++ b/EmployeeHierarchy.Domain/Models/Response/EmployeeHierarchyResponse.cs
@@ -1,0 +1,16 @@
+namespace EmployeeHierarchy.Domain.Models.Response;
+
+public class EmployeeHierarchyResponse
+{
+    public int EmployeeId { get; set; }
+
+    public string FirstName { get; set; }
+
+    public string LastName { get; set; }
+
+    public string PositionName { get; set; }
+
+    public int? ManagerId { get; set; }
+    
+    public int? HierarchyLevel { get; set; }
+}

--- a/EmployeeHierarchy.Infrastructure/Repositories/DeleteClient.cs
+++ b/EmployeeHierarchy.Infrastructure/Repositories/DeleteClient.cs
@@ -3,8 +3,6 @@ namespace EmployeeHierarchy.Infrastructure.Repositories;
 using System.Data;
 using Dapper;
 using Domain;
-using Utils;
-using Domain.Entities;
 
 public class DeleteClient: IDeleteClient
 {

--- a/EmployeeHierarchy.Infrastructure/Repositories/ReadClient.cs
+++ b/EmployeeHierarchy.Infrastructure/Repositories/ReadClient.cs
@@ -1,0 +1,25 @@
+namespace EmployeeHierarchy.Infrastructure.Repositories;
+
+using Domain.Models.Response;
+using System.Data;
+using Dapper;
+using Domain;
+
+public class ReadClient : IReadClient
+{
+    private readonly IDbConnection connection;
+
+    public ReadClient(IDbConnection connection)
+    {
+        this.connection = connection;
+    }
+
+    public async Task<IEnumerable<EmployeeHierarchyResponse>> GetEmployeeHierarchyAsync()
+    {
+        var result = await this.connection.QueryAsync<EmployeeHierarchyResponse>(
+            "sp_get_employee_hierarchy",
+            commandType: CommandType.StoredProcedure);
+
+        return result;
+    }
+}


### PR DESCRIPTION
Added stored procedure `sp_get_employee_hierarchy` to retrieve hierarchical structure of employees including their positions and manager relationships. Implemented corresponding repository method and exposed a new GET endpoint `/api/hierarchy/tree` for frontend consumption. Response is structured for easy transformation into a tree format on the client side.